### PR TITLE
Fix ForgeMultipart client crash when trying to load a multiblock

### DIFF
--- a/Waterfall-Proxy-Patches/0003-1.7.x-Protocol-Patch.patch
+++ b/Waterfall-Proxy-Patches/0003-1.7.x-Protocol-Patch.patch
@@ -1135,7 +1135,7 @@ index 1d75cd0d..5f086f4f 100644
              }
              for ( Score score : serverScoreboard.getScores() )
              {
-@@ -392,14 +403,23 @@ public class ServerConnector extends PacketHandler
+@@ -392,6 +403,14 @@ public class ServerConnector extends PacketHandler
              {
                  this.handshakeHandler.handle( pluginMessage );
  
@@ -1150,19 +1150,6 @@ index 1d75cd0d..5f086f4f 100644
                  // We send the message as part of the handler, so don't send it here.
                  throw CancelSendSignal.INSTANCE;
              }
-+        }else
-+        {
-+            // We have to forward these to the user, especially with Forge as stuff might break
-+            // This includes any REGISTER messages we intercepted earlier.
-+            user.unsafe().sendPacket( pluginMessage );
-         }
--
--        // We have to forward these to the user, especially with Forge as stuff might break
--        // This includes any REGISTER messages we intercepted earlier.
--        user.unsafe().sendPacket( pluginMessage );
-     }
- 
-     @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 index 9c872a1c..32830770 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java


### PR DESCRIPTION
Caused by commit 80367c1 that failed to correctly merge the file

Fix #78 